### PR TITLE
Fix MemoryVFS file list snapshot

### DIFF
--- a/core/disk/vfs.py
+++ b/core/disk/vfs.py
@@ -109,7 +109,8 @@ class MemoryVFS(VirtualFileSystem):
         return "/" + path
 
     def _get_file_list(self) -> list[str]:
-        return self.files.keys()
+        # return a snapshot to avoid exposing the live dict_keys view
+        return list(self.files.keys())
 
 
 class LocalDiskVFS(VirtualFileSystem):

--- a/tests/disk/test_vfs.py
+++ b/tests/disk/test_vfs.py
@@ -86,3 +86,12 @@ def test_local_disk_vfs_with_matcher(tmp_path):
 
     vfs.remove("test.log")
     assert exists(join(tmp_path, "test.log"))
+
+
+def test_memory_vfs_get_file_list_returns_independent_list():
+    vfs = MemoryVFS()
+    vfs.save("first.txt", "data")
+    file_list = vfs._get_file_list()
+    vfs.save("second.txt", "more")
+    assert isinstance(file_list, list)
+    assert file_list == ["first.txt"]


### PR DESCRIPTION
## Summary
- ensure `MemoryVFS._get_file_list` returns a list snapshot instead of a live `dict_keys` view
- add regression test covering snapshot behaviour of `MemoryVFS`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898ee3a5dc08322beffdc8b8be451f4