### PR TITLE
Add simple Supabase-backed full-stack demo

### DIFF
--- a/examples/supabase_fullstack/README.md
+++ b/examples/supabase_fullstack/README.md
@@ -1,0 +1,43 @@
+# Simple Supabase full-stack demo
+
+This demo includes:
+- a **simple backend** (`backend.py`)
+- a **simple frontend** (`static/index.html`)
+- a **database connection to Supabase** via PostgREST
+
+## 1) Create table in Supabase
+
+Run this SQL in the Supabase SQL editor:
+
+```sql
+create table if not exists public.todos (
+  id bigint generated always as identity primary key,
+  title text not null,
+  is_done boolean not null default false,
+  created_at timestamp with time zone not null default now()
+);
+```
+
+If you use RLS, add policies that allow reads/inserts for your chosen key.
+
+## 2) Set environment variables
+
+```bash
+export SUPABASE_URL="https://<project-ref>.supabase.co"
+export SUPABASE_ANON_KEY="<your-anon-or-service-role-key>"
+export SUPABASE_TABLE="todos"
+```
+
+## 3) Run the app
+
+```bash
+python examples/supabase_fullstack/backend.py
+```
+
+Open `http://localhost:8000`.
+
+## API endpoints
+
+- `GET /api/health`
+- `GET /api/todos`
+- `POST /api/todos` with body `{ "title": "Buy milk" }`

--- a/examples/supabase_fullstack/backend.py
+++ b/examples/supabase_fullstack/backend.py
@@ -1,0 +1,147 @@
+import json
+import os
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+SUPABASE_URL = os.getenv("SUPABASE_URL", "").rstrip("/")
+SUPABASE_ANON_KEY = os.getenv("SUPABASE_ANON_KEY", "")
+SUPABASE_TABLE = os.getenv("SUPABASE_TABLE", "todos")
+STATIC_DIR = Path(__file__).parent / "static"
+
+
+class SupabaseClient:
+    def __init__(self, url: str, anon_key: str, table: str):
+        self.url = url
+        self.anon_key = anon_key
+        self.table = table
+
+    @property
+    def configured(self) -> bool:
+        return bool(self.url and self.anon_key)
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "apikey": self.anon_key,
+            "Authorization": f"Bearer {self.anon_key}",
+            "Content-Type": "application/json",
+        }
+
+    def list_rows(self) -> list[dict[str, Any]]:
+        endpoint = f"{self.url}/rest/v1/{self.table}"
+        response = httpx.get(endpoint, headers=self._headers(), params={"select": "*", "order": "id.desc"}, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        if not isinstance(data, list):
+            raise ValueError("Expected a list response from Supabase")
+        return data
+
+    def create_row(self, payload: dict[str, Any]) -> dict[str, Any]:
+        endpoint = f"{self.url}/rest/v1/{self.table}"
+        headers = self._headers() | {"Prefer": "return=representation"}
+        response = httpx.post(endpoint, headers=headers, json=payload, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        if isinstance(data, list) and data:
+            return data[0]
+        raise ValueError("Unexpected insert response from Supabase")
+
+
+SUPABASE = SupabaseClient(SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_TABLE)
+
+
+class AppHandler(BaseHTTPRequestHandler):
+    def _json_response(self, payload: Any, status: int = 200) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_json_body(self) -> dict[str, Any]:
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length) if length > 0 else b"{}"
+        parsed = json.loads(raw.decode("utf-8"))
+        if not isinstance(parsed, dict):
+            raise ValueError("JSON body must be an object")
+        return parsed
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/" or self.path.startswith("/index.html"):
+            self._serve_file("index.html", "text/html; charset=utf-8")
+            return
+
+        if self.path == "/api/health":
+            self._json_response(
+                {
+                    "status": "ok",
+                    "supabase_configured": SUPABASE.configured,
+                    "table": SUPABASE.table,
+                }
+            )
+            return
+
+        if self.path == "/api/todos":
+            if not SUPABASE.configured:
+                self._json_response({"error": "SUPABASE_URL and SUPABASE_ANON_KEY are required."}, 500)
+                return
+            try:
+                rows = SUPABASE.list_rows()
+                self._json_response(rows)
+            except Exception as exc:  # pragma: no cover
+                self._json_response({"error": str(exc)}, 502)
+            return
+
+        self.send_error(HTTPStatus.NOT_FOUND, "Not Found")
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/api/todos":
+            self.send_error(HTTPStatus.NOT_FOUND, "Not Found")
+            return
+
+        if not SUPABASE.configured:
+            self._json_response({"error": "SUPABASE_URL and SUPABASE_ANON_KEY are required."}, 500)
+            return
+
+        try:
+            payload = self._read_json_body()
+            title = str(payload.get("title", "")).strip()
+            if not title:
+                self._json_response({"error": "title is required"}, 400)
+                return
+
+            row = SUPABASE.create_row({"title": title, "is_done": False})
+            self._json_response(row, 201)
+        except json.JSONDecodeError:
+            self._json_response({"error": "Invalid JSON body"}, 400)
+        except Exception as exc:  # pragma: no cover
+            self._json_response({"error": str(exc)}, 502)
+
+    def _serve_file(self, filename: str, content_type: str) -> None:
+        file_path = STATIC_DIR / filename
+        if not file_path.exists():
+            self.send_error(HTTPStatus.NOT_FOUND, "Not Found")
+            return
+
+        content = file_path.read_bytes()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(content)))
+        self.end_headers()
+        self.wfile.write(content)
+
+
+def run() -> None:
+    host = os.getenv("HOST", "0.0.0.0")
+    port = int(os.getenv("PORT", "8000"))
+    server = ThreadingHTTPServer((host, port), AppHandler)
+    print(f"Server started on http://{host}:{port}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    run()

--- a/examples/supabase_fullstack/static/index.html
+++ b/examples/supabase_fullstack/static/index.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Supabase Todo Demo</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 640px;
+        margin: 40px auto;
+        padding: 0 12px;
+      }
+      form {
+        display: flex;
+        gap: 8px;
+      }
+      input {
+        flex: 1;
+        padding: 8px;
+      }
+      button {
+        padding: 8px 12px;
+      }
+      li {
+        margin: 8px 0;
+      }
+      .muted {
+        color: #666;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Simple Supabase Todo App</h1>
+    <p class="muted">Backend + frontend + Supabase table integration.</p>
+
+    <form id="todo-form">
+      <input id="todo-title" type="text" placeholder="Write a todo" required />
+      <button type="submit">Add</button>
+    </form>
+
+    <h2>Todos</h2>
+    <ul id="todo-list"></ul>
+
+    <script>
+      const form = document.getElementById('todo-form');
+      const input = document.getElementById('todo-title');
+      const list = document.getElementById('todo-list');
+
+      function itemTemplate(todo) {
+        return `<li><strong>#${todo.id ?? '-'}</strong> ${todo.title}</li>`;
+      }
+
+      async function loadTodos() {
+        const response = await fetch('/api/todos');
+        const data = await response.json();
+        if (!response.ok) {
+          list.innerHTML = `<li>${data.error || 'Could not load todos.'}</li>`;
+          return;
+        }
+
+        list.innerHTML = data.map(itemTemplate).join('') || '<li>No todos yet.</li>';
+      }
+
+      form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+
+        const title = input.value.trim();
+        if (!title) return;
+
+        const response = await fetch('/api/todos', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ title }),
+        });
+
+        if (response.ok) {
+          input.value = '';
+          await loadTodos();
+          return;
+        }
+
+        const error = await response.json();
+        alert(error.error || 'Could not add todo.');
+      });
+
+      loadTodos();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a minimal full-stack example that demonstrates wiring a backend + frontend to Supabase PostgREST. 
- Offer an easy-to-run demo for users to try CRUD-style flow against a Supabase table with minimal setup. 
- Keep the example framework-agnostic and dependency-light so it can be used as a starting point for integrations.

### Description
- Add `examples/supabase_fullstack/backend.py`, a tiny Python HTTP server that includes a `SupabaseClient` using `httpx`, serves static files, and exposes `GET /api/health`, `GET /api/todos`, and `POST /api/todos` endpoints. 
- Add `examples/supabase_fullstack/static/index.html`, a minimal frontend that lists todos and posts new todos to the backend. 
- Add `examples/supabase_fullstack/README.md` with the SQL schema for a `todos` table, required environment variables, run instructions, and endpoint documentation. 
- Backend reads `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `SUPABASE_TABLE` from the environment and interacts with Supabase via PostgREST endpoints.

### Testing
- Ran `python -m py_compile examples/supabase_fullstack/backend.py`, which completed successfully. 
- Started the server and ran `curl -s http://127.0.0.1:8000/api/health`, which returned a JSON health response with `"status": "ok"` and `"supabase_configured": false` (indicating env vars were not set). 
- Used automated browser tooling to load the frontend and capture a screenshot; the first Playwright attempt timed out and a subsequent run completed successfully and produced a screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6d0c8806c832295d67481bc420ac8)